### PR TITLE
Use writings repo directly in dev instead of symlink

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -111,8 +111,5 @@ export default defineConfig({
         nesting: true,
       }),
     ],
-    resolve: {
-      preserveSymlinks: true,
-    },
   },
 });

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-echo "Creating symlink for posts..."
-ln -fs ../../../personal-content--writings/posts src/content/posts
-
-echo "Done!"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -19,7 +19,9 @@ const samplePostsCollection = defineCollection({
 const postsCollection = defineCollection({
   loader: glob({
     pattern: "**/[^_]*.{md,mdx}",
-    base: "./src/content/posts",
+    base: import.meta.env.PROD
+      ? "./src/content/posts"
+      : "../personal-content--writings/posts",
   }),
   schema: z.object({
     title: z.string(),


### PR DESCRIPTION
Astro 5 doesn't require that content be in `src/content` anymore, it can be anywhere.